### PR TITLE
Agilent changed their device string to keysight. This occured with th…

### DIFF
--- a/xlab/instruments/manufacturers/agilent/a34xxx.py
+++ b/xlab/instruments/manufacturers/agilent/a34xxx.py
@@ -117,11 +117,11 @@ class A34xxx(Instrument):
             
 
 class A34405(A34xxx):
-    id_match = r'Agilent Technologies,34405.?,'
+    id_match = r'.+Technologies,34405.?,'
     channels = 1
 
 class A34450(A34xxx):
-    id_match = r'Agilent Technologies,34450.?,'
+    id_match = r'.+Technologies,34450.?,'
     channels = 2
     timeout = 4
 


### PR DESCRIPTION
…e a34xxx we tested, but might happen more often in the future (new devices or firmware updates).

(from wikipedia: In 2014, Keysight was spun off from Agilent Technologies, taking with it the product lines focused on electronics and radio, leaving Agilent with the chemical and bio-analytical products.[4])